### PR TITLE
v2.0.1, the last version compatible with Polly v6.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Polly.Caching.Distributed change log
 
+## 2.0.1
+- No functional changes
+- Indicate compatibility with Polly &lt; v7
+
 ## 2.0.0
 - Provide a single signed package only.
 - Update Polly to V6.0.1.

--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 2.0.0
+next-version: 2.0.1

--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ This project, Polly.Caching.Distributed, allows you to use Polly's `CachePolicy`
 
 Polly.Caching.Distributed supports .NET Standard 1.1 and .NET Standard 2.0.
 
-## Dependencies
+## Versions and Dependencies
+
+Polly.Caching.Distributed &gt;=v2.0 and &lt;v3 requires:
+
++ [Polly](nuget.org/packages/polly) >= v6.0.1 and &lt;v7.
++ [Microsoft.Extensions.Caching.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Abstractions/) v2.0.2 or above.
 
 Polly.Caching.IDistributedCache &lt;v2.0 requires:
 
 + [Polly](nuget.org/packages/polly) v5.4.0 or above.
 + [Microsoft.Extensions.Caching.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Abstractions/) v1.1.2 or above.
 
-Polly.Caching.Distributed &gt;=v2.0 requires:
-
-+ [Polly](nuget.org/packages/polly) v6.0.1 or above.
-+ [Microsoft.Extensions.Caching.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Abstractions/) v2.0.2 or above.
 
 # How to use the Polly.Caching.Distributed plugin
 
@@ -84,7 +85,7 @@ public class Startup
 
         services.AddSingleton<Polly.Caching.IAsyncCacheProvider<string>>(serviceProvider => serviceProvider.GetRequiredService<IDistributedCache>().AsAsyncCacheProvider<string>());
 
-        services.AddSingleton<Polly.Registry.IPolicyRegistry<string>, Polly.Registry.PolicyRegistry>((serviceProvider) =>
+        services.AddSingleton<Polly.Registry.IReadOnlyPolicyRegistry<string>, Polly.Registry.PolicyRegistry>((serviceProvider) =>
         {
             PolicyRegistry registry = new PolicyRegistry();
             registry.Add("myCachePolicy", Policy.CacheAsync<string>(serviceProvider.GetRequiredService<IAsyncCacheProvider<string>>(), TimeSpan.FromMinutes(5)));
@@ -98,7 +99,7 @@ public class Startup
 
 // In a controller, inject the policyRegistry and retrieve the policy:
 // (magic string "myCachePolicy" hard-coded here only to keep the example simple) 
-public MyController(IPolicyRegistry<string> policyRegistry)
+public MyController(IReadOnlyPolicyRegistry<string> policyRegistry)
 {
     var _cachePolicy = policyRegistry.Get<IAsyncPolicy<string>>("myCachePolicy"); 
     // ...
@@ -109,7 +110,7 @@ Usage:
 
 ```csharp
 string productId = // ... from somewhere
-string productDescription = await cachePolicy.ExecuteAsync(context => getProductDescription(productId), 
+string productDescription = await _cachePolicy.ExecuteAsync(context => getProductDescription(productId), 
     new Context(productId) // productId will also be the cache key used in this execution.
 ); 
 ```

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 [assembly: AssemblyProduct("Polly.Caching.Distributed")]
 [assembly: AssemblyCompany("App vNext")]
 [assembly: AssemblyDescription("Polly.Caching.Distributed is a IDistributedCache plug-in for the Polly CachePolicy.  Polly is a library that allows developers to express resilience and transient fault handling policies such as Retry, Circuit Breaker, Timeout, Bulkhead Isolation, and Fallback in a fluent and thread-safe manner.")]
-[assembly: AssemblyCopyright("Copyright (c) 2017, App vNext")]
+[assembly: AssemblyCopyright("Copyright (c) 2019, App vNext")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]

--- a/src/Polly.Caching.Distributed.NetStandard11/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Distributed.NetStandard11/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Distributed")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 [assembly: CLSCompliant(false)] // Because Microsoft.Extensions.Caching.Memory.IDistributedCache, on which Polly.Caching.IDistributedCache.NetStandard11 depends, is not CLSCompliant.
 
 [assembly: InternalsVisibleTo("Polly.Caching.Distributed.NetStandard11.Specs")]

--- a/src/Polly.Caching.Distributed.NetStandard20/Properties/AssemblyInfo.cs
+++ b/src/Polly.Caching.Distributed.NetStandard20/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Polly.Caching.Distributed")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyInformationalVersion("2.0.1.0")]
 [assembly: CLSCompliant(false)] // Because Microsoft.Extensions.Caching.Memory.IDistributedCache, on which Polly.Caching.IDistributedCache.NetStandard11 depends, is not CLSCompliant.
 
 [assembly: InternalsVisibleTo("Polly.Caching.Distributed.NetStandard20.Specs")]

--- a/src/Polly.Caching.Distributed.nuspec
+++ b/src/Polly.Caching.Distributed.nuspec
@@ -34,7 +34,6 @@
         <dependency id="Microsoft.Extensions.Caching.Abstractions" version="1.1.2" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="Polly" version="6.0.1" />
         <dependency id="Microsoft.Extensions.Caching.Abstractions" version="2.0.2" />
       </group>

--- a/src/Polly.Caching.Distributed.nuspec
+++ b/src/Polly.Caching.Distributed.nuspec
@@ -13,6 +13,11 @@
     <tags>Polly Cache Caching Cache-aside</tags>
     <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
+     2.0.1
+     ---------------------
+     - No functional changes
+     - Indicate compatibility with Polly &lt; v7
+
      2.0.0
      ---------------------
      - Provide a single signed package only.
@@ -30,11 +35,11 @@
     <dependencies>
       <group targetFramework="netstandard1.1">
         <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="[6.0.1,7)" />
         <dependency id="Microsoft.Extensions.Caching.Abstractions" version="1.1.2" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Polly" version="6.0.1" />
+        <dependency id="Polly" version="[6.0.1,7)" />
         <dependency id="Microsoft.Extensions.Caching.Abstractions" version="2.0.2" />
       </group>
     </dependencies>

--- a/src/Polly.Caching.Distributed.nuspec
+++ b/src/Polly.Caching.Distributed.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly.Caching.IDistributedCache</projectUrl>
     <tags>Polly Cache Caching Cache-aside</tags>
-    <copyright>Copyright © 2017, App vNext</copyright>
+    <copyright>Copyright © 2019, App vNext</copyright>
     <releaseNotes>
      2.0.0
      ---------------------

--- a/src/Polly.Caching.Distributed.nuspec
+++ b/src/Polly.Caching.Distributed.nuspec
@@ -7,7 +7,7 @@
       Polly.Caching.Distributed is a plug-in for the .NET OSS resilience library Polly, supporting Microsoft.Extensions.Caching.Distributed.IDistributedCache as a provider for Polly's CachePolicy.
     </description>
     <language>en-US</language>
-    <licenseUrl>https://raw.github.com/App-vNext/Polly/master/LICENSE.txt</licenseUrl>
+    <license type="expression">BSD-3-Clause</license>
     <iconUrl>https://raw.github.com/App-vNext/Polly/master/Polly.png</iconUrl>
     <projectUrl>https://github.com/App-vNext/Polly.Caching.IDistributedCache</projectUrl>
     <tags>Polly Cache Caching Cache-aside</tags>


### PR DESCRIPTION
Create a v2.0.1, flagged as the last version compatible with Polly v6.*

+ Also fixes #11 : License tag element in nuspec
+ Also fixes #9 : NetStandard 2.0 dependencies
