### PR TITLE
Pass cancellation token for recent .net frameworks

### DIFF
--- a/src/Polly.Caching.Distributed/NetStandardIDistributedCacheByteArrayProvider.cs
+++ b/src/Polly.Caching.Distributed/NetStandardIDistributedCacheByteArrayProvider.cs
@@ -56,7 +56,7 @@ namespace Polly.Caching.Distributed
             cancellationToken.ThrowIfCancellationRequested();
 
             byte[] fromCache = await _cache.GetAsync(key
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
                 , cancellationToken
 #endif
             );
@@ -77,7 +77,7 @@ namespace Polly.Caching.Distributed
             cancellationToken.ThrowIfCancellationRequested();
 
             return _cache.SetAsync(key, value, ttl.ToDistributedCacheEntryOptions()
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
                 , cancellationToken
 #endif
             );

--- a/src/Polly.Caching.Distributed/NetStandardIDistributedCacheStringProvider.cs
+++ b/src/Polly.Caching.Distributed/NetStandardIDistributedCacheStringProvider.cs
@@ -57,7 +57,7 @@ namespace Polly.Caching.Distributed
             cancellationToken.ThrowIfCancellationRequested();
 
             string fromCache = await _cache.GetStringAsync(key
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
                 , cancellationToken
 #endif
                 );
@@ -78,7 +78,7 @@ namespace Polly.Caching.Distributed
             cancellationToken.ThrowIfCancellationRequested();
 
             return _cache.SetStringAsync(key, value, ttl.ToDistributedCacheEntryOptions()
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
                 , cancellationToken
 #endif
                 );


### PR DESCRIPTION
Solves an issue, when CancellationToken is not passed to underlaying cache implementation for .net core/netstandard2.1 or higher.
This can cause an issue in some edge scenarios, when call (for example to Redis) gets stuck - possible due to some network issue.

Fixes this issue: https://github.com/App-vNext/Polly.Caching.IDistributedCache/issues/21
